### PR TITLE
Adding support for project-specific template folders (specified in <y…

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,5 +1,9 @@
 [
     {
+        "caption": "Tmpl: Create project-specific", "command": "sublime_tmpl",
+        "args": {"type": "project"}
+    },
+    {
         "caption": "Tmpl: Create html", "command": "sublime_tmpl",
         "args": {"type": "html"}
     },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -9,6 +9,14 @@
                 "children":
                 [
                     {
+                        "id": "project",
+                        "caption": "Project Specific",
+                        "command": "sublime_tmpl",
+                        "args": {
+                            "type": "project"
+                        }
+                    },
+                    {
                         "id": "html",
                         "caption": "HTML",
                         "command": "sublime_tmpl",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Custom settings (**Recommend*): `Preferences` > `Package Settings` > `SublimeTmp
 
 Default template files: `Packages/SublimeTmpl/templates`
 
-Custom template files (**Recommend*): `Packages/User/SublimeTmpl/templates/`
+Custom template files (**Recommend**): `Packages/User/SublimeTmpl/templates/`
+
+Project-specific template files (ST3 only): "template_folder" key within your sublime-project file.
 
 
 Default key bindings
@@ -134,7 +136,7 @@ FAQ
 --------------------
 Source: [https://github.com/kairyou/SublimeTmpl][0]
 
-Docs: [中文文档](https://xhl.me/archives/sublime-template-engine-sublimetmpl/)
+Docs: [中文文档](http://www.fantxi.com/blog/archives/sublime-template-engine-sublimetmpl/)
 
 
 [0]: https://github.com/kairyou/SublimeTmpl

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -5,6 +5,15 @@
         "children":
         [
             {
+                "id": "project",
+                "caption": "Project Specific",
+                "command": "sublime_tmpl",
+                "args": {
+                    "type": "project",
+                    "paths": [],
+                }
+            },
+            {
                 "id": "html",
                 "caption": "HTML",
                 "command": "sublime_tmpl",


### PR DESCRIPTION
…ourproject>.sublime-project file).

* Opens a quick panel to select project-specific templates.
Additional tweaks:
* Replaced setting paths parameter = [None] to avoid list parameter issues in Python.  creat_tab() will set it if None is passed in.
* Introduced with() context manager to ensure files are closed in the event of exceptions.
* Introduced is_resource_path(), format_as_resource_path(), get_project_template_folder(), get_template_folders() to support loading non-resource folders and reduce ST2/ST3 code paths.