### PR TITLE
Project specific template

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,5 +1,9 @@
 [
     {
+        "caption": "Tmpl: Create project-specific", "command": "sublime_tmpl",
+        "args": {"type": "project"}
+    },
+    {
         "caption": "Tmpl: Create html", "command": "sublime_tmpl",
         "args": {"type": "html"}
     },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -9,6 +9,14 @@
                 "children":
                 [
                     {
+                        "id": "project",
+                        "caption": "Project Specific",
+                        "command": "sublime_tmpl",
+                        "args": {
+                            "type": "project"
+                        }
+                    },
+                    {
                         "id": "html",
                         "caption": "HTML",
                         "command": "sublime_tmpl",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Custom settings (**Recommend*): `Preferences` > `Package Settings` > `SublimeTmp
 
 Default template files: `Packages/SublimeTmpl/templates`
 
-Custom template files (**Recommend*): `Packages/User/SublimeTmpl/templates/`
+Custom template files (**Recommend**): `Packages/User/SublimeTmpl/templates/`
+
+Project-specific template files (ST3 only): "template_folder" key within your sublime-project file.
 
 
 Default key bindings
@@ -134,7 +136,7 @@ FAQ
 --------------------
 Source: [https://github.com/kairyou/SublimeTmpl][0]
 
-Docs: [中文文档](https://xhl.me/archives/sublime-template-engine-sublimetmpl/)
+Docs: [中文文档](http://www.fantxi.com/blog/archives/sublime-template-engine-sublimetmpl/)
 
 
 [0]: https://github.com/kairyou/SublimeTmpl

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Install [Package Control][1]. Then `Package Control: Install Package`, look for 
 Usage
 -----
 
-- Creat file with menu
+- Create file with menu
    `File - New File (SublimeTmpl)`
 
-- Creat file with command
+- Create file with command
    use `cmd+shift+p` then look for `tmpl:`
 
 Settings
@@ -36,7 +36,7 @@ Default template files: `Packages/SublimeTmpl/templates`
 
 Custom template files (**Recommend**): `Packages/User/SublimeTmpl/templates/`
 
-Project-specific template files (ST3 only): "template_folder" key within your sublime-project file.
+Project-specific template files (ST3 only): via `settings`: `SublimeTmpl`: `template_folder` key within your sublime-project file (see "Features added" below)
 
 
 Default key bindings
@@ -64,7 +64,8 @@ To disable all default shortcuts, set value to `all`.
 
 - custom template files
 
-    > put your custom template files in `Packages/User/SublimeTmpl/templates`  
+    > put your custom template files in `Packages/User/SublimeTmpl/templates` 
+    > Project-specific template files can be specified in project files, along with overriding other templating options.
 
 - `*.tmpl` file support `${date}` variable
 
@@ -97,6 +98,38 @@ It is recommended that you put your own custom settings in `settings - user`.  P
 ```
 
     > The `*.tmpl` file will support `${author}` `${email}` `${link}` `${hello}` variables.
+
+- Project specific overrides via `SublimeTmpl` attribute in sublime-project file.
+    >
+``` json
+    "settings":
+    {
+        "SublimeTmpl":
+        {
+            "template_folder": "Path\\to\\some\\custom\\template\\folder",
+            "template_replace_pattern": "{{%s}}",
+            "enable_project_variables": true,
+            "enable_file_variables_on_save": true,
+            "attr": {  // Fully overrides "attr" settings (i.e. elements missing here will not attempt to be replaced in template)
+                "author": "Alternative Name"
+            },
+            "project_variables": {
+                // Allows for use with other template formats, provide mapping here
+                // "tmpl_formatted_name": "current_template_name"
+                "project_base_name": "projectbase",
+                "project_path": "projectpath",
+                "platform": "plat"
+            },
+            
+            "file_variables_on_save": {
+                // Allows for use with other template formats, provide mapping here
+                // "tmpl_formatted_name": "current_template_name"
+                "saved_filename": "name",
+                "saved_filepath": "filepath"
+            },
+        },
+    },
+```
 
 *Detailed Instructions for Sublime Newbies
 -----------------------------------------

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -5,6 +5,15 @@
         "children":
         [
             {
+                "id": "project",
+                "caption": "Project Specific",
+                "command": "sublime_tmpl",
+                "args": {
+                    "type": "project",
+                    "paths": [],
+                }
+            },
+            {
                 "id": "html",
                 "caption": "HTML",
                 "command": "sublime_tmpl",

--- a/SublimeTmpl.sublime-settings
+++ b/SublimeTmpl.sublime-settings
@@ -105,12 +105,28 @@
         "extension": "yaml"
     },
     "disable_keymap_actions": false, // "all"; "html,css"
-    "enable_project_variables": false, // ${project_base_name}, ${project_path} and ${platform}
-    "enable_file_variables_on_save": false, // ${saved_filename}, ${saved_filepath} on save file
+    "enable_project_variables": false,
+    "enable_file_variables_on_save": false,
     "date_format" : "%Y-%m-%d %H:%M:%S",
     "attr": {
         "author": "Your Name",
         "email": "you@example.org",
         "link": "http://example.org"
-    }
+    },
+    "project_variables": {
+        // Allows for use with other template formats, provide mapping here
+        // "tmpl_formatted_name": "current_template_name"
+        "project_base_name": "project_base_name",
+        "project_path": "project_path",
+        "platform": "platform"
+    },
+    
+    "file_variables_on_save": {
+        // Allows for use with other template formats, provide mapping here
+        // "tmpl_formatted_name": "current_template_name"
+        "saved_filename": "saved_filename",
+        "saved_filepath": "saved_filepath"
+    },
+    "template_replace_pattern": "${%s}",
+    "template_extension": ".tmpl"
 }


### PR DESCRIPTION
Adding support for project-specific template customizations (including product-specific template folders).

* Provide ability to specify setting overrides per project.
* Customize template extension, replacement pattern, and mapping for project and "on save" variables to integrate with alternative template formats.
* New menu/sidebar option added for project-specific templates.  Opens a quick panel to select any found templates.

Additional tweaks:
* Replaced setting paths parameter = [None] to avoid list parameter issues in Python.  creat_tab() will set it if None is passed in.
* Introduced with() context manager to ensure files are closed in the event of exceptions.
* Introduced is_resource_path(), format_as_resource_path(), get_project_template_folder(), get_template_folders() to support loading non-resource folders and reduce ST2/ST3 code paths.
* Introduced new get_settings() and support class to load both project and plugin settings and fallback gracefully if key not found.